### PR TITLE
Update rpxc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ also view all of the addons by using:
 ```
 aws s3 ls s3://mozilla-gateway-addons/
 ```
+
+# Building the docker cross compiler image
+
+To build the docker image, do the following steps:
+```
+git clone https://github.com/mozilla-iot/docker-raspberry-pi-cross-compiler.git
+cd docker-raspberry-pi-cross-compiler
+git checkout rpxc-stretch
+export RPXC_IMAGE=dhylands/raspberry-pi-cross-compiler-stretch
+./build.sh
+docker push ${RPXC_IMAGE}
+```
+If you're not dhylands then you'll need to change the username appropriately,
+and also modify the create-rpxc.sh script in this repository.

--- a/create-rpxc.sh
+++ b/create-rpxc.sh
@@ -7,14 +7,5 @@ mkdir -p $(dirname ${RPXC})
 
 # Build the docker raspberry pi cross compiler
 echo "Creating rpxc"
-docker run sdthirlwall/raspberry-pi-cross-compiler > ${RPXC}
+docker run dhylands/raspberry-pi-cross-compiler-stretch > ${RPXC}
 chmod +x ${RPXC}
-
-sudo ${RPXC} apt update
-sudo ${RPXC} apt upgrade
-
-${RPXC} install-raspbian libudev-dev
-${RPXC} install-debian pkg-config
-${RPXC} install-debian python
-${RPXC} install-debian python2.7
-${RPXC} install-debian unzip


### PR DESCRIPTION
The rpxc that we've been using is based on jessie and there seem to be some issues installing some of the debian packages (inparticular the file package required by python). This sort of updates the docker image to be based on stretch and we can now build adapters.

This also installs all of the needed packages into the docker image so which should speed up the builds a bit.

The repository for the docker image has been put into mozilla-iot: https://github.com/mozilla-iot/docker-raspberry-pi-cross-compiler.

The docker image is built from the rpxc-stretch branch and the resulting docker image is hosted on hub.docker.com as dhylands/raspberry-pi-cross-compiler-stretch