### PR TITLE
Allow build a PR for a particular adapter

### DIFF
--- a/build-adapter.sh
+++ b/build-adapter.sh
@@ -109,6 +109,11 @@ fi
 
 ADDON_ARCH=${ADDON_ARCH} ./package.sh
 for TARFILE in *-${ADDON_ARCH}*.tgz; do
+  if [ -n "${PULL_REQUEST}" ]; then
+    NEW_TARFILE="${TARFILE/${ADDON_ARCH}/-pr-${PULL_REQUEST}-${ADDON_ARCH}}"
+    mv "${TARFILE}" "${NEW_TARFILE}"
+    TARFILE="${NEW_TARFILE}"
+  fi
   sha256sum "${TARFILE}" > "${TARFILE}.sha256sum"
   mv "${TARFILE}" ../builder/
   mv "${TARFILE}.sha256sum" ../builder/

--- a/build-addons.sh
+++ b/build-addons.sh
@@ -53,8 +53,27 @@ case "${TRAVIS_OS_NAME}" in
 
 esac
 
+if [ -n "${PULL_REQUEST}" ]; then
+  if [ "${#ADAPTERS[@]}" != 1 ]; then
+    echo "Must specify exactly one adapter when using pull request option."
+    exit 1
+  fi
+  if ! [[ "${PULL_REQUEST}" =~ ^[0-9]+$ ]]; then
+    echo "Expecting numeric pull request; Got '${PULL_REQUEST}'"
+    exit 1
+  fi
+fi
+
 git submodule update --init --remote
 git submodule status
+
+if [ -n "${PULL_REQUEST}" ]; then
+  (
+    cd ${ADAPTERS}
+    git fetch -fu origin pull/${PULL_REQUEST}/head:pr/origin/${PULL_REQUEST}
+  )
+fi
+
 mkdir -p builder
 
 if [ -z "${ADAPTERS}" ]; then

--- a/trigger-build.sh
+++ b/trigger-build.sh
@@ -18,8 +18,26 @@ addEnv() {
 
 VERBOSE=0
 
-while getopts "hv:" opt "$@"; do
+while getopts "hv-:" opt "$@"; do
   case ${opt} in
+
+    -)
+      case ${OPTARG} in
+        pr)
+          PULL_REQUEST="${!OPTIND}"
+          OPTIND=$(( $OPTIND + 1 ))
+          ;;
+
+        help)
+          usage
+          ;;
+
+        *)
+          echo "Unrecognized option: ${OPTARG}"
+          exit 1
+          ;;
+      esac
+      ;;
 
     h)
       usage
@@ -41,11 +59,27 @@ shift $((OPTIND-1))
 ADAPTERS="$@"
 
 if [ "${VERBOSE}" == 1 ]; then
-  echo "ADAPTERS = '${ADAPTERS}"
+  echo "ADAPTERS = '${ADAPTERS}'"
+  echo "PULL_REQUEST = '${PULL_REQUEST}'"
+fi
+
+if ! [[ "${PULL_REQUEST}" =~ ^[0-9]+$ ]]; then
+  echo "Expecting numeric pull request; Got '${PULL_REQUEST}'"
+  exit 1
+fi
+if [ -n "${PULL_REQUEST}" ]; then
+  if [ "${#ADAPTERS[@]}" != 1 ]; then
+    echo "Must specify exactly one adapter when using pull request option."
+    exit 1
+  fi
 fi
 
 if [ -n "${ADAPTERS}" ]; then
   addEnv ADAPTERS "${ADAPTERS}"
+fi
+
+if [ -n "${PULL_REQUEST}" ]; then
+  addEnv PULL_REQUEST "${PULL_REQUEST}"
 fi
 
 if [ "${VERBOSE}" == 1 ]; then


### PR DESCRIPTION
These changes allow a PR to build built by specifying the --pr followed by the PR number on the trigger-build.sh command line.