### PR TITLE
Remove thing-url-adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,9 +6,6 @@
 	path = serial-adapter
 	url = https://github.com/mozilla-iot/serial-adapter
 	branch = master
-[submodule "thing-url-adapter"]
-	path = thing-url-adapter
-	url = https://github.com/mozilla-iot/thing-url-adapter
 [submodule "zigbee-adapter"]
 	path = zigbee-adapter
 	url = https://github.com/mozilla-iot/zigbee-adapter

--- a/build-addons.sh
+++ b/build-addons.sh
@@ -85,7 +85,6 @@ if [ -z "${ADAPTERS}" ]; then
     lg-tv-adapter
     microblocks-adapter
     serial-adapter
-    thing-url-adapter
     zigbee-adapter
     zwave-adapter
   )


### PR DESCRIPTION
The thing-url-adapter no longer has any native
code dependencies, so doesn't need to be built
via the addon-builder.