### PR TITLE
Document the --pr command line option

### DIFF
--- a/trigger-build.sh
+++ b/trigger-build.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_NAME=$(basename $0)
 
 usage() {
-  echo "Usage: ${SCRIPT_NAME} ADAPTER-NAME..."
+  echo "Usage: ${SCRIPT_NAME} [--pr PR] ADAPTER-NAME..."
 }
 
 ENV=
@@ -30,6 +30,7 @@ while getopts "hv-:" opt "$@"; do
 
         help)
           usage
+          exit 1
           ;;
 
         *)


### PR DESCRIPTION
This adds mention of --pr when trigger-build.sh is run
with -h or --help.
It also causes --help to not trigger a build