### PR TITLE
awox-mesh-light-adapter: Add module v0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,3 +80,6 @@
 [submodule "influxdb-bridge"]
 	path = influxdb-bridge
 	url = https://github.com/tim-hellhake/influxdb-bridge
+[submodule "awox-mesh-light-adapter"]
+	path = awox-mesh-light-adapter
+	url = https://github.com/rzr/awox-mesh-light-webthing

--- a/build-addons.sh
+++ b/build-addons.sh
@@ -46,6 +46,7 @@ mkdir -p builder
 if [ -z "${ADAPTERS}" ]; then
   # No adapters were provided via the environment, build them all
   ADAPTERS=(
+    awox-mesh-light-adapter:python
     blinkt-adapter:node
     bmp280-adapter:node
     enocean-adapter:node


### PR DESCRIPTION
This version is a "dummy addon" without depedencies

Forwarded: https://github.com/mozilla-iot/addon-builder/pulls
Relate-to: https://github.com/mozilla-iot/addon-list/pull/851
Signed-off-by: Philippe Coval <rzr@users.sf.net>
Change-Id: I819f8259297047449ff09a4e0460673059755a17