### PR TITLE
awox-mesh-light-adapter: Exclude darwin

### DIFF
--- a/build-addons.sh
+++ b/build-addons.sh
@@ -83,6 +83,7 @@ case "${ADDON_ARCH}" in
   darwin-x64)
     RPXC=
     SKIP_ADAPTERS+=(
+      awox-mesh-light-adapter
       blinkt-adapter
       bmp280-adapter
       generic-sensors-adapter


### PR DESCRIPTION
Fell free to file ticket if you have this device

URL: https://github.com/mozilla-iot/addon-list/pull/851
Relate-to: https://github.com/mozilla-iot/addon-builder/runs/723614473
Signed-off-by: Philippe Coval <rzr@users.sf.net>