### PR TITLE
toolchain: Add libglib2.0-dev to python images

### DIFF
--- a/toolchain/linux-arm/python/Dockerfile
+++ b/toolchain/linux-arm/python/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
         libbz2-dev \
         libc6-dev \
         libffi-dev \
+        libglib2.0-dev \
         libgdbm-dev \
         libjpeg-dev \
         liblzma-dev \

--- a/toolchain/linux-arm64/python/Dockerfile
+++ b/toolchain/linux-arm64/python/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update && \
         libc6-dev \
         libffi-dev \
         libgdbm-dev \
+        libglib2.0-dev \
         libjpeg-dev \
         liblzma-dev \
         libncurses5-dev \

--- a/toolchain/linux-x64/python/Dockerfile
+++ b/toolchain/linux-x64/python/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update && \
         libc6-dev \
         libffi-dev \
         libgdbm-dev \
+        libglib2.0-dev \
         libjpeg-dev \
         liblzma-dev \
         libncurses5-dev \


### PR DESCRIPTION
To be used for building upcoming awox-mesh-light-adapter
that is pulling bluepy which it depends on it.

Relate-to: https://github.com/mozilla-iot/addon-list/pull/851
Forwarded: https://github.com/mozilla-iot/addon-builder/pull/55
Signed-off-by: Philippe Coval <rzr@users.sf.net>